### PR TITLE
feat: Create Python script for PDF to Markdown conversion with OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# PDF to Markdown Converter with OCR
+
+This script converts a PDF file into a Markdown file. It uses a hybrid approach:
+1.  It first tries to extract text directly from the PDF. This works best for PDFs that are text-based.
+2.  If a page contains no extractable text (i.e., it's an image), the script uses Optical Character Recognition (OCR) to detect and extract text.
+
+The final output is a single Markdown file where the content of each page is separated by a heading.
+
+## Dependencies
+
+This project requires Python 3.6+ and a few external software packages.
+
+### 1. Python Libraries
+
+Install the required Python libraries using pip:
+```bash
+pip install -r requirements.txt
+```
+
+### 2. External Software
+
+You also need to install **Tesseract-OCR** (for OCR) and **Poppler** (for PDF to image conversion).
+
+#### On Debian/Ubuntu (Linux)
+```bash
+sudo apt-get update
+sudo apt-get install -y tesseract-ocr poppler-utils
+```
+
+#### On Fedora/CentOS/RHEL (Linux)
+```bash
+sudo dnf install -y tesseract poppler-utils
+```
+
+#### On macOS (using Homebrew)
+```bash
+brew install tesseract poppler
+```
+
+#### On Windows
+1.  **Tesseract-OCR**:
+    *   Download and run the installer from [Tesseract at UB Mannheim](https://github.com/UB-Mannheim/tesseract/wiki).
+    *   During installation, make sure to check the option to add Tesseract to your system's PATH. If you forget, you'll need to add it manually (e.g., `C:\Program Files\Tesseract-OCR`).
+2.  **Poppler**:
+    *   Download the latest Poppler binary from [this page](http://blog.alivate.com.au/poppler-windows/).
+    *   Extract the archive (e.g., to `C:\poppler-23.11.0`).
+    *   Add the `bin` directory from the extracted folder (e.g., `C:\poppler-23.11.0\bin`) to your system's PATH.
+
+## How to Run
+
+Use the command-line interface to specify the input PDF file and the desired output path.
+
+### Basic Usage
+
+```bash
+python pdf_to_markdown_converter.py --input path/to/your/file.pdf --output path/to/your/output.md
+```
+
+### Example
+
+If you have a PDF named `report.pdf` in the same directory as the script:
+
+```bash
+python pdf_to_markdown_converter.py --input report.pdf --output report.md
+```
+
+The script will create a file named `report.md` with the converted content. Each page from the PDF will be separated by a header like `## Page 1`, `## Page 2`, etc.

--- a/pdf_to_markdown_converter.py
+++ b/pdf_to_markdown_converter.py
@@ -1,0 +1,129 @@
+import fitz  # PyMuPDF
+import pytesseract
+from pdf2image import convert_from_path
+from PIL import Image
+import os
+import argparse
+
+# --- Optional: Set Tesseract and Poppler paths for Windows ---
+# If Tesseract or Poppler are not in your system's PATH, you can specify their
+# locations here. This is often necessary on Windows.
+#
+# Example for Windows:
+# TESSERACT_CMD = r'C:\Program Files\Tesseract-OCR\tesseract.exe'
+# POPPLER_PATH = r'C:\path\to\poppler-xx.x.x\bin'
+#
+# if os.name == 'nt': # Check if running on Windows
+#     pytesseract.pytesseract.tesseract_cmd = TESSERACT_CMD
+
+def convert_pdf_to_markdown(pdf_path, output_path, poppler_path=None):
+    """
+    Converts a PDF file to a Markdown file using a hybrid text extraction and OCR approach.
+
+    Args:
+        pdf_path (str): The full path to the input PDF file.
+        output_path (str): The full path to save the output Markdown file.
+        poppler_path (str, optional): The path to the Poppler 'bin' directory.
+                                      Required for pdf2image on Windows.
+    """
+    if not os.path.exists(pdf_path):
+        print(f"Error: Input file not found at '{pdf_path}'")
+        return
+
+    # Open the PDF file
+    pdf_document = fitz.open(pdf_path)
+
+    markdown_content = []
+
+    print(f"Processing {len(pdf_document)} pages from '{os.path.basename(pdf_path)}'...")
+
+    for page_num in range(len(pdf_document)):
+        page_index = page_num + 1
+        markdown_content.append(f"## Page {page_index}\n")
+
+        page = pdf_document.load_page(page_num)
+
+        # 1. Try to extract text directly
+        text = page.get_text("text")
+
+        # 2. If text is minimal, use OCR
+        # A small threshold helps decide if the page is image-based.
+        if len(text.strip()) < 100:
+            print(f"Page {page_index}: Minimal text found. Attempting OCR...")
+            try:
+                # Convert page to image
+                images = convert_from_path(
+                    pdf_path,
+                    dpi=300,
+                    first_page=page_index,
+                    last_page=page_index,
+                    poppler_path=poppler_path
+                )
+
+                if images:
+                    # Use Pytesseract to extract text from the image
+                    ocr_text = pytesseract.image_to_string(images[0], lang='eng') # Specify language if needed
+                    text = ocr_text
+                    print(f"Page {page_index}: OCR successful.")
+                else:
+                    print(f"Page {page_index}: Could not convert page to image.")
+                    text = "" # No text could be extracted
+            except Exception as e:
+                print(f"Page {page_index}: OCR failed with error: {e}")
+                text = "*(OCR failed for this page)*"
+        else:
+            print(f"Page {page_index}: Extracted text directly.")
+
+        # Append the extracted text to our content list
+        markdown_content.append(text.strip() + "\n")
+
+    # Write the combined content to the output file
+    try:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write("\n".join(markdown_content))
+        print(f"\nSuccessfully converted PDF to Markdown at: '{output_path}'")
+    except IOError as e:
+        print(f"Error: Could not write to output file '{output_path}'. Reason: {e}")
+
+    # Close the PDF document
+    pdf_document.close()
+
+def main():
+    """
+    Main function to handle command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Convert a PDF file to a Markdown file using direct text extraction and OCR.",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the input PDF file."
+    )
+
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to the output Markdown (.md) file."
+    )
+
+    parser.add_argument(
+        "--poppler_path",
+        required=False,
+        default=None,
+        help="(Optional for Windows) Path to the Poppler 'bin' directory.\n"
+             "Needed if Poppler is not in your system's PATH environment variable."
+    )
+
+    args = parser.parse_args()
+
+    # On Windows, if tesseract is not in PATH, uncomment and set the path
+    # if os.name == 'nt':
+    #     pytesseract.pytesseract.tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract.exe'
+
+    convert_pdf_to_markdown(args.input, args.output, args.poppler_path)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyMuPDF==1.23.26
+pdf2image==1.17.0
+pytesseract==0.3.10
+Pillow==10.1.0


### PR DESCRIPTION
This commit introduces a complete Python program to convert PDF files into Markdown (.md) files.

The script implements a hybrid approach to handle both text-based and image-based PDFs:
1. It first attempts to extract text directly using PyMuPDF (fitz).
2. If a page contains minimal text, it falls back to OCR using pytesseract and pdf2image to ensure content from scanned pages is captured.

Key Features:
- Command-Line Interface (CLI) using `argparse` for specifying input and output files (`--input`, `--output`).
- Each page of the PDF is separated by a Markdown header (e.g., `## Page 1`).
- Includes a comprehensive `README.md` with detailed installation instructions for dependencies (Tesseract, Poppler) on Windows, Linux, and macOS.
- A `requirements.txt` file is provided for easy installation of Python libraries.